### PR TITLE
*Don't* check if `fd` is installed before installing.

### DIFF
--- a/download.js
+++ b/download.js
@@ -71,12 +71,6 @@ async function checkRequirements() {
       `Missing required commands: ${missingCommands.join(", ")}.`
     );
   }
-
-  if (await commandExists("fd")) {
-    throw new Error(
-      `Command 'fd' already exists in your $PATH, so nothing will be installed.`
-    );
-  }
 }
 
 function main() {

--- a/download.js
+++ b/download.js
@@ -1,6 +1,9 @@
 const { request } = require("https");
 const os = require("os");
+const fs = require("fs/promises");
+const util = require("util");
 const { exec } = require("child_process");
+const exec_promise = util.promisify(exec);
 
 const platform = os.platform();
 
@@ -9,17 +12,15 @@ const platformFiles = {
   darwin: "apple-darwin",
 };
 
-const commandExists = (cmd) => {
-  return new Promise((resolve, _reject) => {
-    exec(
-      `command -v ${cmd} >/dev/null 2>&1 || { echo >&2 "false"; }`,
-      (error, _stdout, stderr) => {
-        const exists = stderr.trim() !== "false" && !error;
-        resolve(exists);
-      }
-    );
-  });
+const commandExists = async cmd => {
+	return await exec_promise(`command -v '${cmd}'`)
+    .catch(_ => false)
+    .then(({stdout}) => fs.access(stdout.trim(), fs.constants.X_OK)
+        .then(_ => true)
+        .catch(_ => false)
+    )
 };
+
 
 const chooseAsset = (assets) => {
   if (!platformFiles.hasOwnProperty(platform)) {


### PR DESCRIPTION
Checking has several issues:
1. On updates, `fd` is already installed, resulting in a failure
2. The package.json includes `"bin": { "fd": "dist/fd" }`, which gets installed before the script runs, resulting in the script *always* failing.
3. There is *no* reason to deny multiple instances of `fd` on a system. Perhaps I have `fd` installed through `apt`, but *also* want to have the latest version through `npm`. This commit (if it worked correctly) blocks this use case.

This reverts part of 141ff54, and #1. This "feature" is broken and undesirable.

This also refactors the `commandExists` command to make it more readable and ensure that commands with spaces don't break it (by adding quotes)